### PR TITLE
Add url protocol

### DIFF
--- a/rest-http-apis.markdown
+++ b/rest-http-apis.markdown
@@ -30,7 +30,7 @@
 
 ## Projects
 
-- [Hydra: Hypermedia-Driven Web APIs](www.hydra-cg.com)
+- [Hydra: Hypermedia-Driven Web APIs](http://www.hydra-cg.com)
 - [JSON API: A Standard For Building APIs in JSON](http://jsonapi.org/)
 
 


### PR DESCRIPTION
Without protocol, Github will render a link to the url https://github.com/turicas/braindump/blob/loading/www.hydra-cg.com
